### PR TITLE
IPv6 Implemented

### DIFF
--- a/CHANGELOG.log
+++ b/CHANGELOG.log
@@ -1,4 +1,17 @@
 ===============================================================================
+| 2 Mar 2016                                                                  |
+-------------------------------------------------------------------------------
+
+  TODO:
+  - Implement an inverse function (probably using ~) that is effectively
+    Ipv4(addr) ^ Ipv4('255.255.255.255')
+  - Define some useful predefined addresses like a loopback address or global
+    broadcast
+  - Document Ipv4
+  - Still have to do pretty much everything for Ipv6
+  - At some point have some sort of built in function to tunnel Ipv4 over Ipv6?
+
+===============================================================================
 | 1 Mar 2016                                                                  |
 -------------------------------------------------------------------------------
 

--- a/CHANGELOG.log
+++ b/CHANGELOG.log
@@ -1,14 +1,19 @@
 ===============================================================================
+| 3 Mar 2016                                                                  |
+-------------------------------------------------------------------------------
+
+ - Added ~ support for Ipv4
+ - Added a LOOPBACK and GLOBAL_BROADCAST (seemed like it might come in handy)
+ - Also added GLOBAL_BROADCAST to Ipv6, should rename to something else later
+   since IPv6 doesn't actually have such a thing
+ - Added IPv6 support! :D
+
+===============================================================================
 | 2 Mar 2016                                                                  |
 -------------------------------------------------------------------------------
 
   TODO:
-  - Implement an inverse function (probably using ~) that is effectively
-    Ipv4(addr) ^ Ipv4('255.255.255.255')
-  - Define some useful predefined addresses like a loopback address or global
-    broadcast
   - Document Ipv4
-  - Still have to do pretty much everything for Ipv6
   - At some point have some sort of built in function to tunnel Ipv4 over Ipv6?
 
 ===============================================================================

--- a/ip/__init__.py
+++ b/ip/__init__.py
@@ -11,3 +11,6 @@ __author__ = 'foxfluff/luma'
 __url__ = 'https://github.com/foxfluff'
 
 __all__ = ['Ip', 'Ipv4', 'Ipv6']
+
+IPV4_LOOPBACK = Ipv4([127, 0, 0, 1])
+IPV4_GLOBAL_BROADCAST = Ipv4([255, 255, 255, 255])

--- a/ip/ipv4.py
+++ b/ip/ipv4.py
@@ -98,4 +98,7 @@ class Ipv4(ip.Ip):
         return self ^ other
 
 
+    def __invert__(self):
+        return Ipv4(self ^ Ipv4([255, 255, 255, 255]))
+
 __all__ = ['Ipv4']

--- a/ip/ipv4.py
+++ b/ip/ipv4.py
@@ -3,8 +3,6 @@ import ip
 class Ipv4(ip.Ip):
 
     _delimiter = '.'
-    LOOPBACK = [127, 0, 0, 1]
-    GLOBAL_BROADCAST = [255, 255, 255, 255]
 
     @property
     def address(self):
@@ -101,6 +99,6 @@ class Ipv4(ip.Ip):
 
 
     def __invert__(self):
-        return Ipv4(self ^ Ipv4(self.GLOBAL_BROADCAST))
+        return Ipv4(self ^ (2 ** 32 - 1))
 
 __all__ = ['Ipv4']

--- a/ip/ipv4.py
+++ b/ip/ipv4.py
@@ -3,6 +3,8 @@ import ip
 class Ipv4(ip.Ip):
 
     _delimiter = '.'
+    LOOPBACK = Ipv4([127, 0, 0, 1])
+    GLOBAL_BROADCAST = Ipv4([255, 255, 255, 255])
 
     @property
     def address(self):
@@ -99,6 +101,6 @@ class Ipv4(ip.Ip):
 
 
     def __invert__(self):
-        return Ipv4(self ^ Ipv4([255, 255, 255, 255]))
+        return Ipv4(self ^ self.GLOBAL_BROADCAST)
 
 __all__ = ['Ipv4']

--- a/ip/ipv4.py
+++ b/ip/ipv4.py
@@ -3,8 +3,8 @@ import ip
 class Ipv4(ip.Ip):
 
     _delimiter = '.'
-    LOOPBACK = Ipv4([127, 0, 0, 1])
-    GLOBAL_BROADCAST = Ipv4([255, 255, 255, 255])
+    LOOPBACK = [127, 0, 0, 1]
+    GLOBAL_BROADCAST = [255, 255, 255, 255]
 
     @property
     def address(self):
@@ -20,7 +20,7 @@ class Ipv4(ip.Ip):
             # [255, 255, 255, 255] -> 0b11111111 11111111 11111111 11111111
             _addr = 0
             for octet in range(4):
-                _addr += addr[octet] * 2 ** (8 * (3 - octet))
+                _addr += addr[octet] << (8 * (3 - octet))
             return _addr
 
         def string_addr(addr):
@@ -59,8 +59,8 @@ class Ipv4(ip.Ip):
         # converts an int to a list
         # 0b11111111 11111111 11111111 11111111 -> [255, 255, 255, 255]
         addr = []
-        for i in range(4):
-            addr += [255 & self.address >> (8 * (3 - i))]
+        for octet in range(4):
+            addr += [255 & self.address >> (8 * (3 - octet))]
         return iter(map(int, addr))
 
 
@@ -101,6 +101,6 @@ class Ipv4(ip.Ip):
 
 
     def __invert__(self):
-        return Ipv4(self ^ self.GLOBAL_BROADCAST)
+        return Ipv4(self ^ Ipv4(self.GLOBAL_BROADCAST))
 
 __all__ = ['Ipv4']

--- a/ip/ipv4.py
+++ b/ip/ipv4.py
@@ -52,7 +52,7 @@ class Ipv4(ip.Ip):
 
 
     def __str__(self):
-        return ".".join(map(str,tuple(self)))
+        return self._delimiter.join(map(str,tuple(self)))
 
 
     def __iter__(self):

--- a/ip/ipv6.py
+++ b/ip/ipv6.py
@@ -5,11 +5,11 @@ class Ipv6(Ip):
     _delimiter = ':'
     # technically speaking there is no global broadcast, need to find a better
     # term for this.
-    GLOBAL_BROADCAST = Ipv6("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF")
+    GLOBAL_BROADCAST = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
 
     @property
     def address(self):
-        return super(Ipv6, self).address()
+        return super(Ipv6, self).address
 
     @address.setter
     def address(self, address):
@@ -23,10 +23,41 @@ class Ipv6(Ip):
                 #_addr += addr[octet] * 2 ** (8 * (3 - octet))
             #return _addr
             #eww copy paste
-            pass
+            _addr = 0
+            _digit = 0
+            for digit in range(8):
+                # assume hex if a string? base10 if an int? sure why not
+                # convert to int for ease of use I suppose.
+                if isinstance(addr[digit], str):
+                    _digit = int(addr[digit], 16)
+                elif (isinstance(addr[digit], int) or
+                    isinstance(addr[digit], long)):
+
+                    _digit = int(addr[digit])
+                _addr += _digit << (16 * (7 - digit))
+
+            return _addr
 
         def string_addr(addr):
-            pass
+            _addr = addr.split(self._delimiter)
+            if _addr[:2] == ['', ''] or _addr[-2:] == ['', '']:
+                # special case when '::' is on the outer most digit, causes
+                # .split to behave in a way we don't like
+                _addr.remove('')
+            if '' in _addr:
+                location = _addr.index('')
+                _addr.remove('')
+                _addr = (
+                    _addr[:location] +
+                    ([0] * (8 - len(_addr))) +
+                    _addr[location:])
+            if '' in _addr:
+                #indicates two '::', which is not possible in ipv6 addresses
+                print _addr, location
+                raise ValueError(
+                    'Expected at most one "%s", IPv6 does not support more' %
+                    (self._delimiter * 2))
+            return list_addr(_addr)
 
         if isinstance(address, str):
             self._address = string_addr(address)
@@ -47,12 +78,12 @@ class Ipv6(Ip):
     def _hex_digit(self, digit):
         # >>> hex(65535)[2:].rjust(4,'0')
         # 'ffff'
-        return hex(digit)[2:].rjust(4,'0')
+        return hex(digit)[2:].rjust(4, '0')
 
 
     def _dec_digit(self, digit):
         # this seems silly
-        return digit
+        return int(digit)
 
 
     def __init__(self, address):
@@ -60,7 +91,7 @@ class Ipv6(Ip):
 
 
     def __repr__(self):
-        return "%s('%s')" %("Ipv6", str(self))
+        return "%s('%s')" % ("Ipv6", str(self))
 
 
     def __str__(self):
@@ -72,7 +103,11 @@ class Ipv6(Ip):
 
 
     def __iter__(self):
-        pass
+        # GLORIOUS COPY PASTE/MINOR TWEAKS
+        addr = []
+        for digit in range(8):
+            addr += [65535 & self.address >> (16 * (7 - digit))]
+        return iter(map(self._dec_digit, addr))
 
 
     def __getitem__(self, index):
@@ -112,6 +147,6 @@ class Ipv6(Ip):
 
 
     def __invert__(self):
-        return Ipv6(self ^ self.GLOBAL_BROADCAST)
+        return Ipv6(self ^ Ipv6(self.GLOBAL_BROADCAST))
 
 __all__ = ['Ipv6']

--- a/ip/ipv6.py
+++ b/ip/ipv6.py
@@ -5,7 +5,6 @@ class Ipv6(Ip):
     _delimiter = ':'
     # technically speaking there is no global broadcast, need to find a better
     # term for this.
-    GLOBAL_BROADCAST = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
 
     @property
     def address(self):
@@ -53,7 +52,6 @@ class Ipv6(Ip):
                     _addr[location:])
             if '' in _addr:
                 #indicates two '::', which is not possible in ipv6 addresses
-                print _addr, location
                 raise ValueError(
                     'Expected at most one "%s", IPv6 does not support more' %
                     (self._delimiter * 2))
@@ -127,7 +125,7 @@ class Ipv6(Ip):
 
 
     def __rand__(self, other):
-        return self.address & other
+        return self & other
 
 
     def __or__(self, other):
@@ -135,7 +133,7 @@ class Ipv6(Ip):
 
 
     def __ror__(self, other):
-        return self.address | other
+        return self | other
 
 
     def __xor__(self, other):
@@ -143,10 +141,10 @@ class Ipv6(Ip):
 
 
     def __rxor__(self, other):
-        return self.address ^ other
+        return self ^ other
 
 
     def __invert__(self):
-        return Ipv6(self ^ Ipv6(self.GLOBAL_BROADCAST))
+        return Ipv6(self ^ (2 ** 128 - 1))
 
 __all__ = ['Ipv6']

--- a/ip/ipv6.py
+++ b/ip/ipv6.py
@@ -2,17 +2,61 @@ from ip import Ip
 
 class Ipv6(Ip):
 
+    _delimiter = ':'
+    # technically speaking there is no global broadcast, need to find a better
+    # term for this.
+    GLOBAL_BROADCAST = Ipv6("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF")
+
     @property
     def address(self):
         return super(Ipv6, self).address()
 
     @address.setter
     def address(self, address):
+        def list_addr(addr):
+            if len(addr) != 8:
+                raise ValueError('Expected 8 octet address, got %i in (%s)' %
+                                 (len(addr), address))
+            # converts a list into a single long
+            _addr = 0
+            #for octet in range(4):
+                #_addr += addr[octet] * 2 ** (8 * (3 - octet))
+            #return _addr
+            #eww copy paste
+            pass
+
+        def string_addr(addr):
+            pass
+
+        if isinstance(address, str):
+            self._address = string_addr(address)
+        elif isinstance(address, tuple) or isinstance(address, list):
+            self._address = list_addr(address)
+        elif isinstance(address, int) or isinstance(address, long):
+            self._address = address
+        elif isinstance(address, Ipv6):
+            self._address = list_addr(list(address))
+        else:
+            raise TypeError(
+                'Unsupported type for address initialization %s, (%s)' % (
+                    type(address), address)
+                )
         pass
 
 
+    def _hex_digit(self, digit):
+        # >>> hex(65535)[2:].rjust(4,'0')
+        # 'ffff'
+        return hex(digit)[2:].rjust(4,'0')
+
+
+    def _dec_digit(self, digit):
+        # this seems silly
+        return digit
+
+
     def __init__(self, address):
-        super(Ipv6, self).__init__()
+        super(Ipv6, self).__init__(address)
 
 
     def __repr__(self):
@@ -22,7 +66,9 @@ class Ipv6(Ip):
     def __str__(self):
         # should probably implement shorthand version, probably in a seperate
         # funcion
-        return ":".join(tuple(self))
+        return self._delimiter.join(
+            map(self._hex_digit, tuple(self))
+            )
 
 
     def __iter__(self):
@@ -34,22 +80,38 @@ class Ipv6(Ip):
 
 
     def __add__(self, other):
-        return self.address + other
+        return Ipv6(self.address + other)
 
 
     def __sub__(self, other):
-        return self.address - other
+        return Ipv6(self.address - other)
 
 
     def __and__(self, other):
+        return Ipv6(self.address & other)
+
+
+    def __rand__(self, other):
         return self.address & other
 
 
     def __or__(self, other):
+        return Ipv6(self.address | other)
+
+
+    def __ror__(self, other):
         return self.address | other
 
 
     def __xor__(self, other):
+        return Ipv6(self.address ^ other)
+
+
+    def __rxor__(self, other):
         return self.address ^ other
+
+
+    def __invert__(self):
+        return Ipv6(self ^ self.GLOBAL_BROADCAST)
 
 __all__ = ['Ipv6']

--- a/test.py
+++ b/test.py
@@ -34,13 +34,13 @@ print
 
 addr6_1 = ip.Ipv6('fe20:0:0:0:0:0:0:1')
 addr6_2 = ip.Ipv6('fe80::0:1')
-addr6_3 = ip.Ipv6('::ffff:ffff:ffff:ffff')
+addr6_3 = ip.Ipv6('ffff:ffff::0')
 
 print 'self.address', addr6_1.address, addr6_2.address, addr6_3.address
-print 'repr        ', repr(addr6_1), repr(addr6_2)
-print 'str         ', str(addr6_1), str(addr6_2)
-print 'list        ', list(addr6_1), list(addr6_2)
-print 'tuple       ', tuple(addr6_1), tuple(addr6_2)
+print 'repr        ', repr(addr6_1), repr(addr6_2), repr(addr6_3)
+print 'str         ', str(addr6_1), str(addr6_2), str(addr6_3)
+print 'list        ', list(addr6_1), list(addr6_2), list(addr6_3)
+print 'tuple       ', tuple(addr6_1), tuple(addr6_2), tuple(addr6_3)
 print 'ip1 + 5     ', addr6_1 + 5, type(addr6_1 + 5)
 print 'ip2 + 5     ', addr6_2 + 5, type(addr6_2 + 5)
 print 'ip1 - 5     ', addr6_1 - 5, type(addr6_1 - 5)
@@ -51,3 +51,4 @@ print 'ip1 ^ ip2   ', addr6_1 ^ addr6_2, type(addr6_1 ^ addr6_2)
 print 'ip1[0]      ', addr6_1[0]
 print 'ip2[0]      ', addr6_2[0]
 print '~ip3        ', ~addr6_3
+print

--- a/test.py
+++ b/test.py
@@ -15,7 +15,7 @@ addr4_1 = ip.Ipv4('192.168.0.1')
 addr4_2 = ip.Ipv4([172, 16, 0, 1])
 addr4_3 = ip.Ipv4((255, 255, 255, 0))
 
-print 'self.address', addr4_1.address, addr4_2.address
+print 'self.address', addr4_1.address, addr4_2.address, addr4_3.address
 print 'repr        ', repr(addr4_1), repr(addr4_2)
 print 'str         ', str(addr4_1), str(addr4_2)
 print 'list        ', list(addr4_1), list(addr4_2)
@@ -29,5 +29,25 @@ print 'ip1 & ip2   ', addr4_1 & addr4_2, type(addr4_1 & addr4_2)
 print 'ip1 ^ ip2   ', addr4_1 ^ addr4_2, type(addr4_1 ^ addr4_2)
 print 'ip1[0]      ', addr4_1[0]
 print 'ip2[0]      ', addr4_2[0]
-print 'ip3 ^ 255*  ', ip.Ipv4(addr4_3 ^ ip.Ipv4('255.255.255.255'))
 print '~ip3        ', ~addr4_3
+print
+
+addr6_1 = ip.Ipv6('fe20:0:0:0:0:0:0:1')
+addr6_2 = ip.Ipv6('fe80::0:1')
+addr6_3 = ip.Ipv6('::ffff:ffff:ffff:ffff')
+
+print 'self.address', addr6_1.address, addr6_2.address, addr6_3.address
+print 'repr        ', repr(addr6_1), repr(addr6_2)
+print 'str         ', str(addr6_1), str(addr6_2)
+print 'list        ', list(addr6_1), list(addr6_2)
+print 'tuple       ', tuple(addr6_1), tuple(addr6_2)
+print 'ip1 + 5     ', addr6_1 + 5, type(addr6_1 + 5)
+print 'ip2 + 5     ', addr6_2 + 5, type(addr6_2 + 5)
+print 'ip1 - 5     ', addr6_1 - 5, type(addr6_1 - 5)
+print 'ip2 - 5     ', addr6_2 - 5, type(addr6_2 - 5)
+print 'ip1 | ip2   ', addr6_1 | addr6_2, type(addr6_1 | addr6_2)
+print 'ip1 & ip2   ', addr6_1 & addr6_2, type(addr6_1 & addr6_2)
+print 'ip1 ^ ip2   ', addr6_1 ^ addr6_2, type(addr6_1 ^ addr6_2)
+print 'ip1[0]      ', addr6_1[0]
+print 'ip2[0]      ', addr6_2[0]
+print '~ip3        ', ~addr6_3

--- a/test.py
+++ b/test.py
@@ -13,6 +13,7 @@ print
 
 addr4_1 = ip.Ipv4('192.168.0.1')
 addr4_2 = ip.Ipv4([172, 16, 0, 1])
+addr4_3 = ip.Ipv4((255, 255, 255, 0))
 
 print 'self.address', addr4_1.address, addr4_2.address
 print 'repr        ', repr(addr4_1), repr(addr4_2)
@@ -28,3 +29,5 @@ print 'ip1 & ip2   ', addr4_1 & addr4_2, type(addr4_1 & addr4_2)
 print 'ip1 ^ ip2   ', addr4_1 ^ addr4_2, type(addr4_1 ^ addr4_2)
 print 'ip1[0]      ', addr4_1[0]
 print 'ip2[0]      ', addr4_2[0]
+print 'ip3 ^ 255*  ', ip.Ipv4(addr4_3 ^ ip.Ipv4('255.255.255.255'))
+print '~ip3        ', ~addr4_3


### PR DESCRIPTION
yup

```
addr1 = ip.Ip(1234)
self.address 1234
repr         Ip(1234)
ip + 5       Ip(1239) <class 'ip.ip.Ip'>
ip - 5       Ip(1239) <class 'ip.ip.Ip'>

addr4_1 = ip.Ipv4('192.168.0.1')
addr4_2 = ip.Ipv4([172, 16, 0, 1])
addr4_3 = ip.Ipv4((255, 255, 255, 0))
self.address 3232235521 2886729729 4294967040
repr         Ipv4('192.168.0.1') Ipv4('172.16.0.1')
str          192.168.0.1 172.16.0.1
list         [192, 168, 0, 1] [172, 16, 0, 1]
tuple        (192, 168, 0, 1) (172, 16, 0, 1)
ip1 + 5      192.168.0.6 <class 'ip.ipv4.Ipv4'>
ip2 + 5      172.16.0.6 <class 'ip.ipv4.Ipv4'>
ip1 - 5      192.167.255.252 <class 'ip.ipv4.Ipv4'>
ip2 - 5      172.15.255.252 <class 'ip.ipv4.Ipv4'>
ip1 | ip2    236.184.0.1 <class 'ip.ipv4.Ipv4'>
ip1 & ip2    128.0.0.1 <class 'ip.ipv4.Ipv4'>
ip1 ^ ip2    108.184.0.0 <class 'ip.ipv4.Ipv4'>
ip1[0]       192
ip2[0]       172
~ip3         0.0.0.255

addr6_1 = ip.Ipv6('fe20:0:0:0:0:0:0:1')
addr6_2 = ip.Ipv6('fe80::0:1')
addr6_3 = ip.Ipv6('ffff:ffff::0')
self.address 337790064428841746201679969193742565377 338288524927261089654018896841347694593 340282366841710300949110269838224261120
repr         Ipv6('fe20:0000:0000:0000:0000:0000:0000:0001') Ipv6('fe80:0000:0000:0000:0000:0000:0000:0001') Ipv6('ffff:ffff:0000:0000:0000:0000:0000:0000')
str          fe20:0000:0000:0000:0000:0000:0000:0001 fe80:0000:0000:0000:0000:0000:0000:0001 ffff:ffff:0000:0000:0000:0000:0000:0000
list         [65056, 0, 0, 0, 0, 0, 0, 1] [65152, 0, 0, 0, 0, 0, 0, 1] [65535, 65535, 0, 0, 0, 0, 0, 0]
tuple        (65056, 0, 0, 0, 0, 0, 0, 1) (65152, 0, 0, 0, 0, 0, 0, 1) (65535, 65535, 0, 0, 0, 0, 0, 0)
ip1 + 5      fe20:0000:0000:0000:0000:0000:0000:0006 <class 'ip.ipv6.Ipv6'>
ip2 + 5      fe80:0000:0000:0000:0000:0000:0000:0006 <class 'ip.ipv6.Ipv6'>
ip1 - 5      fe1f:ffff:ffff:ffff:ffff:ffff:ffff:fffc <class 'ip.ipv6.Ipv6'>
ip2 - 5      fe7f:ffff:ffff:ffff:ffff:ffff:ffff:fffc <class 'ip.ipv6.Ipv6'>
ip1 | ip2    fea0:0000:0000:0000:0000:0000:0000:0001 <class 'ip.ipv6.Ipv6'>
ip1 & ip2    fe00:0000:0000:0000:0000:0000:0000:0001 <class 'ip.ipv6.Ipv6'>
ip1 ^ ip2    00a0:0000:0000:0000:0000:0000:0000:0000 <class 'ip.ipv6.Ipv6'>
ip1[0]       65056
ip2[0]       65152
~ip3         0000:0000:ffff:ffff:ffff:ffff:ffff:ffff
```

Works as expected
